### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/zeep/cache.py
+++ b/src/zeep/cache.py
@@ -66,7 +66,7 @@ class SqliteCache(object):
 
     @property
     def _version_string(self):
-        prefix = u'$ZEEP:%s$' % self._version
+        prefix = u'$ZEEP:{0!s}$'.format(self._version)
         return bytes(prefix.encode('ascii'))
 
 

--- a/src/zeep/client.py
+++ b/src/zeep/client.py
@@ -33,7 +33,7 @@ class ServiceProxy(object):
         try:
             self._binding.get(key)
         except KeyError:
-            raise AttributeError('Service has no operation %r' % key)
+            raise AttributeError('Service has no operation {0!r}'.format(key))
         return OperationProxy(self, key)
 
 

--- a/src/zeep/parser.py
+++ b/src/zeep/parser.py
@@ -28,7 +28,7 @@ def parse_xml(content, transport, parser_context=None, base_url=None):
     try:
         return fromstring(content, parser=parser, base_url=base_url)
     except etree.XMLSyntaxError as exc:
-        raise XMLSyntaxError("Invalid XML content received (%s)" % exc.message)
+        raise XMLSyntaxError("Invalid XML content received ({0!s})".format(exc.message))
 
 
 def load_external(url, transport, parser_context=None, base_url=None):

--- a/src/zeep/wsdl/definitions.py
+++ b/src/zeep/wsdl/definitions.py
@@ -29,7 +29,7 @@ class AbstractMessage(object):
         self.parts = OrderedDict()
 
     def __repr__(self):
-        return '<%s(name=%r)>' % (self.__class__.__name__, self.name.text)
+        return '<{0!s}(name={1!r})>'.format(self.__class__.__name__, self.name.text)
 
     def resolve(self, definitions):
         pass
@@ -127,7 +127,7 @@ class PortType(object):
         self.operations = operations
 
     def __repr__(self):
-        return '<%s(name=%r)>' % (
+        return '<{0!s}(name={1!r})>'.format(
             self.__class__.__name__, self.name.text)
 
     def resolve(self, definitions):
@@ -194,7 +194,7 @@ class Binding(object):
         return self.__class__.__name__
 
     def __repr__(self):
-        return '<%s(name=%r, port_type=%r)>' % (
+        return '<{0!s}(name={1!r}, port_type={2!r})>'.format(
             self.__class__.__name__, self.name.text, self.port_type)
 
     def get(self, name):
@@ -229,16 +229,16 @@ class Operation(object):
         self.abstract = self.binding.port_type.operations[self.name]
 
     def __repr__(self):
-        return '<%s(name=%r, style=%r)>' % (
+        return '<{0!s}(name={1!r}, style={2!r})>'.format(
             self.__class__.__name__, self.name, self.style)
 
     def __str__(self):
         if not self.input:
-            return u'%s(missing input message)' % (self.name)
+            return u'{0!s}(missing input message)'.format((self.name))
 
-        retval = u'%s(%s)' % (self.name, self.input.signature())
+        retval = u'{0!s}({1!s})'.format(self.name, self.input.signature())
         if self.output:
-            retval += u' -> %s' % (self.output.signature(as_output=True))
+            retval += u' -> {0!s}'.format((self.output.signature(as_output=True)))
         return retval
 
     def create(self, *args, **kwargs):
@@ -280,12 +280,12 @@ class Port(object):
         self.binding_options = None
 
     def __repr__(self):
-        return '<%s(name=%r, binding=%r, %r)>' % (
+        return '<{0!s}(name={1!r}, binding={2!r}, {3!r})>'.format(
             self.__class__.__name__, self.name, self.binding,
             self.binding_options)
 
     def __str__(self):
-        return u'Port: %s (%s)' % (self.name, self.binding)
+        return u'Port: {0!s} ({1!s})'.format(self.name, self.binding)
 
     def send(self, client, operation, args, kwargs):
         return self.binding.send(
@@ -330,10 +330,10 @@ class Service(object):
         self._is_resolved = False
 
     def __str__(self):
-        return u'Service: %s' % self.name
+        return u'Service: {0!s}'.format(self.name)
 
     def __repr__(self):
-        return '<%s(name=%r, ports=%r)>' % (
+        return '<{0!s}(name={1!r}, ports={2!r})>'.format(
             self.__class__.__name__, self.name, self.ports)
 
     def resolve(self, definitions):

--- a/src/zeep/wsdl/http.py
+++ b/src/zeep/wsdl/http.py
@@ -58,7 +58,7 @@ class HttpPostBinding(HttpBinding):
         """Called from the service"""
         operation_obj = self.get(operation)
         if not operation_obj:
-            raise ValueError("Operation %r not found" % operation)
+            raise ValueError("Operation {0!r} not found".format(operation))
 
         serialized = operation_obj.create(*args, **kwargs)
 
@@ -86,7 +86,7 @@ class HttpGetBinding(HttpBinding):
         """Called from the service"""
         operation_obj = self.get(operation)
         if not operation_obj:
-            raise ValueError("Operation %r not found" % operation)
+            raise ValueError("Operation {0!r} not found".format(operation))
 
         serialized = operation_obj.create(*args, **kwargs)
 

--- a/src/zeep/wsdl/messages.py
+++ b/src/zeep/wsdl/messages.py
@@ -44,7 +44,7 @@ class ConcreteMessage(object):
 
         result = self.body.type.signature()
         if getattr(self, 'header', None):
-            result += ', _soapheader=%s' % self.header
+            result += ', _soapheader={0!s}'.format(self.header)
         return result
 
     @classmethod
@@ -203,7 +203,7 @@ class DocumentMessage(SoapMessage):
         result = []
         for part in self.abstract.parts.values():
             elm = node.find(part.element.qname)
-            assert elm is not None, '%s not found' % part.element.qname
+            assert elm is not None, '{0!s} not found'.format(part.element.qname)
             result.append(part.element.parse(elm, self.wsdl.schema))
 
         if len(result) > 1:
@@ -352,7 +352,7 @@ class UrlReplacement(HttpMessage):
 
         path = self.operation.location
         for key, value in params.items():
-            path = path.replace('(%s)' % key, value if value is not None else '')
+            path = path.replace('({0!s})'.format(key), value if value is not None else '')
         return SerializedMessage(path=path, headers=headers, content='')
 
     @classmethod

--- a/src/zeep/wsdl/soap.py
+++ b/src/zeep/wsdl/soap.py
@@ -73,7 +73,7 @@ class SoapBinding(Binding):
         """
         operation_obj = self.get(operation)
         if not operation_obj:
-            raise ValueError("Operation %r not found" % operation)
+            raise ValueError("Operation {0!r} not found".format(operation))
 
         # Create the SOAP envelope
         serialized = operation_obj.create(*args, **kwargs)
@@ -108,15 +108,13 @@ class SoapBinding(Binding):
         """
         if response.status_code != 200 and not response.content:
             raise TransportError(
-                u'Server returned HTTP status %d (no content available)'
-                % response.status_code)
+                u'Server returned HTTP status {0:d} (no content available)'.format(response.status_code))
 
         try:
             doc = fromstring(response.content)
         except etree.XMLSyntaxError:
             raise TransportError(
-                u'Server returned HTTP status %d (%s)'
-                % (response.status_code, response.content))
+                u'Server returned HTTP status {0:d} ({1!s})'.format(response.status_code, response.content))
 
         if client.wsse:
             client.wsse.verify(doc)

--- a/src/zeep/wsdl/utils.py
+++ b/src/zeep/wsdl/utils.py
@@ -6,6 +6,6 @@ def _soap_element(xmlelement, key):
     ]
 
     for ns in namespaces:
-        retval = xmlelement.find('soap:%s' % key, namespaces={'soap': ns})
+        retval = xmlelement.find('soap:{0!s}'.format(key), namespaces={'soap': ns})
         if retval is not None:
             return retval

--- a/src/zeep/wsdl/wsdl.py
+++ b/src/zeep/wsdl/wsdl.py
@@ -69,13 +69,13 @@ class Document(object):
         self.services = root_definitions.services
 
     def __repr__(self):
-        return '<WSDL(location=%r)>' % self.location
+        return '<WSDL(location={0!r})>'.format(self.location)
 
     def dump(self):
         print('')
         print("Prefixes:")
         for prefix, namespace in self.schema._prefix_map.items():
-            print(' ' * 4, '%s: %s' % (prefix, namespace))
+            print(' ' * 4, '{0!s}: {1!s}'.format(prefix, namespace))
 
         print('')
         print("Global elements:")
@@ -99,7 +99,7 @@ class Document(object):
                     key=operator.attrgetter('name'))
 
                 for operation in operations:
-                    print('%s%s' % (' ' * 12, six.text_type(operation)))
+                    print('{0!s}{1!s}'.format(' ' * 12, six.text_type(operation)))
                 print('')
 
     def _load_content(self, location):
@@ -158,7 +158,7 @@ class Definition(object):
         self.services = self.parse_service(doc)
 
     def __repr__(self):
-        return '<Definition(location=%r)>' % self.location
+        return '<Definition(location={0!r})>'.format(self.location)
 
     def get(self, name, key):
         container = getattr(self, name)
@@ -169,7 +169,7 @@ class Definition(object):
             container = getattr(definition, name)
             if key in container:
                 return container[key]
-        raise IndexError("No definition %r found" % name)
+        raise IndexError("No definition {0!r} found".format(name))
 
     def resolve_imports(self):
         """Resolve all root elements (types, messages, etc)."""
@@ -296,7 +296,7 @@ class Definition(object):
         schema_ns = {}
         for i, schema_node in enumerate(schema_nodes):
             ns = schema_node.get('targetNamespace')
-            int_name = schema_ns[ns] = 'intschema:xsd%d' % i
+            int_name = schema_ns[ns] = 'intschema:xsd{0:d}'.format(i)
             self.wsdl._parser_context.schema_nodes.add(schema_ns[ns], schema_node)
             self.wsdl._parser_context.schema_locations[int_name] = self.location
 
@@ -310,7 +310,7 @@ class Definition(object):
 
             # Create a new xsd:import element to import the schema
             import_node = etree.Element(import_tag)
-            import_node.set('schemaLocation', 'intschema:xsd%d' % i)
+            import_node.set('schemaLocation', 'intschema:xsd{0:d}'.format(i))
             if schema_node.get('targetNamespace'):
                 import_node.set('namespace', schema_node.get('targetNamespace'))
             container.append(import_node)

--- a/src/zeep/wsse/username.py
+++ b/src/zeep/wsse/username.py
@@ -59,7 +59,7 @@ class UsernameToken(object):
 
         # The token placeholder might already exists since it is specified in
         # the WSDL.
-        token = security.find('{%s}UsernameToken' % NSMAP['wsse'])
+        token = security.find('{{{0!s}}}UsernameToken'.format(NSMAP['wsse']))
         if token is None:
             token = WSSE.UsernameToken()
             security.append(token)
@@ -84,7 +84,7 @@ class UsernameToken(object):
         return [
             WSSE.Password(
                 self.password,
-                Type='%s#PasswordText' % self.username_token_profile_ns)
+                Type='{0!s}#PasswordText'.format(self.username_token_profile_ns))
         ]
 
     def _create_password_digest(self):
@@ -108,11 +108,11 @@ class UsernameToken(object):
         return [
             WSSE.Password(
                 digest,
-                Type='%s#PasswordDigest' % self.username_token_profile_ns
+                Type='{0!s}#PasswordDigest'.format(self.username_token_profile_ns)
             ),
             WSSE.Nonce(
                 base64.b64encode(nonce).decode('utf-8'),
-                EncodingType='%s#Base64Binary' % self.soap_message_secutity_ns
+                EncodingType='{0!s}#Base64Binary'.format(self.soap_message_secutity_ns)
             ),
             WSU.Created(timestamp)
         ]

--- a/src/zeep/xsd/builtins.py
+++ b/src/zeep/xsd/builtins.py
@@ -179,7 +179,7 @@ class gYearMonth(SimpleType):
 
     def xmlvalue(self, value):
         year, month, tzinfo = value
-        return '%04d-%02d%s' % (year, month, _unparse_timezone(tzinfo))
+        return '{0:04d}-{1:02d}{2!s}'.format(year, month, _unparse_timezone(tzinfo))
 
     def pythonvalue(self, value):
         match = self._pattern.match(value)
@@ -202,7 +202,7 @@ class gYear(SimpleType):
 
     def xmlvalue(self, value):
         year, tzinfo = value
-        return '%04d%s' % (year, _unparse_timezone(tzinfo))
+        return '{0:04d}{1!s}'.format(year, _unparse_timezone(tzinfo))
 
     def pythonvalue(self, value):
         match = self._pattern.match(value)
@@ -226,7 +226,7 @@ class gMonthDay(SimpleType):
 
     def xmlvalue(self, value):
         month, day, tzinfo = value
-        return '--%02d-%02d%s' % (month, day, _unparse_timezone(tzinfo))
+        return '--{0:02d}-{1:02d}{2!s}'.format(month, day, _unparse_timezone(tzinfo))
 
     def pythonvalue(self, value):
         match = self._pattern.match(value)
@@ -251,7 +251,7 @@ class gDay(SimpleType):
 
     def xmlvalue(self, value):
         day, tzinfo = value
-        return '---%02d%s' % (day, _unparse_timezone(tzinfo))
+        return '---{0:02d}{1!s}'.format(day, _unparse_timezone(tzinfo))
 
     def pythonvalue(self, value):
         match = self._pattern.match(value)
@@ -272,7 +272,7 @@ class gMonth(SimpleType):
 
     def xmlvalue(self, value):
         month, tzinfo = value
-        return '--%d%s' % (month, _unparse_timezone(tzinfo))
+        return '--{0:d}{1!s}'.format(month, _unparse_timezone(tzinfo))
 
     def pythonvalue(self, value):
         match = self._pattern.match(value)
@@ -492,8 +492,8 @@ def _unparse_timezone(tzinfo):
     minutes = tzinfo._minutes % 60
 
     if hours > 0:
-        return '+%02d:%02d' % (hours, minutes)
-    return '-%02d:%02d' % (abs(hours), minutes)
+        return '+{0:02d}:{1:02d}'.format(hours, minutes)
+    return '-{0:02d}:{1:02d}'.format(abs(hours), minutes)
 
 
 default_types = {

--- a/src/zeep/xsd/elements.py
+++ b/src/zeep/xsd/elements.py
@@ -29,7 +29,7 @@ class Any(Base):
         self.type = AnyType()
 
     def __repr__(self):
-        return '<%s(name=%r)>' % (self.__class__.__name__, self.name)
+        return '<{0!s}(name={1!r})>'.format(self.__class__.__name__, self.name)
 
     def render(self, parent, value):
         assert parent is not None
@@ -59,7 +59,7 @@ class Any(Base):
         return any_object
 
     def signature(self, name=None):
-        return '%s%s: %s' % (
+        return '{0!s}{1!s}: {2!s}'.format(
             name, '=None' if self.is_optional else '',
             '[]' if self.max_occurs != 1 else ''
         )
@@ -81,8 +81,8 @@ class Element(Base):
 
     def __str__(self):
         if self.type:
-            return '%s(%s)' % (self.name, self.type.signature())
-        return '%s()' % self.name
+            return '{0!s}({1!s})'.format(self.name, self.type.signature())
+        return '{0!s}()'.format(self.name)
 
     def __call__(self, *args, **kwargs):
         instance = self.type(*args, **kwargs)
@@ -91,7 +91,7 @@ class Element(Base):
         return instance
 
     def __repr__(self):
-        return '<%s(name=%r, type=%r)>' % (
+        return '<{0!s}(name={1!r}, type={2!r})>'.format(
             self.__class__.__name__, self.name, self.type)
 
     def __eq__(self, other):
@@ -101,8 +101,8 @@ class Element(Base):
             self.__dict__ == other.__dict__)
 
     def signature(self, name=None):
-        assert self.type, '%r has no name' % self
-        return '%s%s: %s%s' % (
+        assert self.type, '{0!r} has no name'.format(self)
+        return '{0!s}{1!s}: {2!s}{3!s}'.format(
             name, '=None' if self.is_optional else '',
             self.type.name, '[]' if self.max_occurs != 1 else ''
         )
@@ -196,7 +196,7 @@ class GroupElement(Element):
         return self.children
 
     def signature(self, name):
-        return '%s%s: %s' % (
+        return '{0!s}{1!s}: {2!s}'.format(
             name, '=None' if self.is_optional else '',
             '[]' if self.max_occurs != 1 else ''
         )
@@ -250,13 +250,13 @@ class Choice(Base):
 
     def signature(self, name):
         part = ' | '.join([
-            '{%s}' % element.signature(element.name)
+            '{{{0!s}}}'.format(element.signature(element.name))
             for element in self.elements
         ])
 
         if self.max_occurs != 1:
-            return '%s: [%s]' % (name, part)
-        return '%s: %s' % (name, part)
+            return '{0!s}: [{1!s}]'.format(name, part)
+        return '{0!s}: {1!s}'.format(name, part)
 
     def parse(self, elements, schema):
         result = []

--- a/src/zeep/xsd/schema.py
+++ b/src/zeep/xsd/schema.py
@@ -69,7 +69,7 @@ class Schema(object):
                     todo.append(schema)
                     assigned.add(schema)
                     if schema._target_namespace:
-                        prefix_map['ns%d' % num] = schema._target_namespace
+                        prefix_map['ns{0:d}'.format(num)] = schema._target_namespace
 
             for schema in todo:
                 _recurse(schema)
@@ -78,7 +78,7 @@ class Schema(object):
         return prefix_map
 
     def __repr__(self):
-        return '<Schema(location=%r, is_empty=%r)>' % (self._location, self.is_empty)
+        return '<Schema(location={0!r}, is_empty={1!r})>'.format(self._location, self.is_empty)
 
     def resolve(self):
         logger.info("Resolving schema %s", self)
@@ -124,7 +124,7 @@ class Schema(object):
             return self._imports[name.namespace].get_type(name)
 
         raise KeyError(
-            "No such type: %r (Only have %s)" % (
+            "No such type: {0!r} (Only have {1!s})".format(
                 name.text, ', '.join(self._types)))
 
     def get_element(self, name):
@@ -136,7 +136,7 @@ class Schema(object):
             return self._imports[name.namespace].get_element(name)
 
         raise KeyError(
-            "No such element: %r (Only have %s) (from: %s)" % (
+            "No such element: {0!r} (Only have {1!s}) (from: {2!s})".format(
                 name.text, ', '.join(self._elements), self))
 
     def get_attribute(self, name):
@@ -148,7 +148,7 @@ class Schema(object):
             return self._imports[name.namespace].get_attribute(name)
 
         raise KeyError(
-            "No such attribute: %r (Only have %s) (from: %s)" % (
+            "No such attribute: {0!r} (Only have {1!s}) (from: {2!s})".format(
                 name.text, ', '.join(self._attributes), self))
 
     def _create_qname(self, name):
@@ -161,7 +161,7 @@ class Schema(object):
                 return etree.QName(self._prefix_map[prefix], localname)
             else:
                 raise ValueError(
-                    "No namespace defined for the prefix %r" % prefix)
+                    "No namespace defined for the prefix {0!r}".format(prefix))
         else:
             return etree.QName(name)
 

--- a/src/zeep/xsd/types.py
+++ b/src/zeep/xsd/types.py
@@ -79,11 +79,11 @@ class SimpleType(Type):
 
     def xmlvalue(self, value):
         raise NotImplementedError(
-            '%s.xmlvalue() not implemented' % self.__class__.__name__)
+            '{0!s}.xmlvalue() not implemented'.format(self.__class__.__name__))
 
     def pythonvalue(self, xmlvalue):
         raise NotImplementedError(
-            '%s.pytonvalue() not implemented' % self.__class__.__name__)
+            '{0!s}.pytonvalue() not implemented'.format(self.__class__.__name__))
 
     def resolve(self, schema):
         return self
@@ -149,10 +149,10 @@ class ComplexType(Type):
         num_choice = 1
         for prop in self._children:
             if isinstance(prop, Any):
-                result.append(('_any_%d' % num_any, prop))
+                result.append(('_any_{0:d}'.format(num_any), prop))
                 num_any += 1
             elif isinstance(prop, Choice):
-                result.append(('_choice_%d' % num_choice, prop))
+                result.append(('_choice_{0:d}'.format(num_choice), prop))
                 num_choice += 1
             elif prop.name is None:
                 result.append(('_value', prop))
@@ -273,7 +273,7 @@ class ComplexType(Type):
 
             else:
                 if not field:
-                    raise ValueError("Unexpected element: %r" % element)
+                    raise ValueError("Unexpected element: {0!r}".format(element))
                     break
 
                 # Element can be optional, so if this doesn't match then assume
@@ -306,7 +306,7 @@ class ComplexType(Type):
         return self.__class__.__name__
 
     def __str__(self):
-        return '%s(%s)' % (self.__class__.__name__, self.signature())
+        return '{0!s}({1!s})'.format(self.__class__.__name__, self.signature())
 
 
 class ListType(Type):

--- a/src/zeep/xsd/valueobjects.py
+++ b/src/zeep/xsd/valueobjects.py
@@ -15,7 +15,7 @@ class AnyObject(object):
         self.value = value
 
     def __repr__(self):
-        return '<%s(type=%r, value=%r)>' % (
+        return '<{0!s}(type={1!r}, value={2!r})>'.format(
             self.__class__.__name__, self.xsd_type, self.value)
 
 
@@ -52,7 +52,7 @@ class ChoiceItem(object):
         self.values = values
 
     def __repr__(self):
-        return '<%s(index=%r, values=%r)>' % (
+        return '<{0!s}(index={1!r}, values={2!r})>'.format(
             self.__class__.__name__, self.index, self.values)
 
     def __eq__(self, other):
@@ -99,7 +99,7 @@ def _process_signature(fields, args, kwargs):
 
     if len(args) > num_pos_args:
         raise TypeError(
-            "__init__() takes at most %s positional arguments (%s given)" % (
+            "__init__() takes at most {0!s} positional arguments ({1!s} given)".format(
                 num_pos_args, len(args)))
 
     # Process the positional arguments
@@ -125,7 +125,7 @@ def _process_signature(fields, args, kwargs):
 
             if isinstance(element, Any) and not isinstance(value, AnyObject):
                 raise TypeError(
-                    "%s: expected AnyObject, %s found" % (
+                    "{0!s}: expected AnyObject, {1!s} found".format(
                         name, type(value).__name__))
 
             result[name] = value

--- a/src/zeep/xsd/visitor.py
+++ b/src/zeep/xsd/visitor.py
@@ -37,7 +37,7 @@ class SchemaVisitor(object):
     def process(self, node, parent):
         visit_func = self.visitors.get(node.tag)
         if not visit_func:
-            raise ValueError("No visitor defined for %r" % node.tag)
+            raise ValueError("No visitor defined for {0!r}".format(node.tag))
         result = visit_func(self, node, parent)
         return result
 
@@ -332,7 +332,7 @@ class SchemaVisitor(object):
         elif child.tag == tags.union:
             xsd_type = self.visit_union(child, node)
         else:
-            raise AssertionError("Unexpected child: %r" % child.tag)
+            raise AssertionError("Unexpected child: {0!r}".format(child.tag))
 
         assert xsd_type is not None
         if not is_anonymous:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bjtucker:python-zeep?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bjtucker:python-zeep?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
